### PR TITLE
Non-blocking mouse events

### DIFF
--- a/SDL/src/video/uikit/SDL_uikitopengles.m
+++ b/SDL/src/video/uikit/SDL_uikitopengles.m
@@ -84,7 +84,9 @@ void UIKit_GL_SwapWindow(_THIS, SDL_Window * window)
 	[data->view swapBuffers];
 	/* since now we've got something to draw
 	   make the window visible */
-	[data->uiwindow makeKeyAndVisible];
+	dispatch_async(dispatch_get_main_queue(), ^{
+        [data->uiwindow makeKeyAndVisible];
+    });
 
 	/* we need to let the event cycle run, or the OS won't update the OpenGL view! */
 	SDL_PumpEvents();

--- a/SDL/src/video/uikit/SDL_uikitview.m
+++ b/SDL/src/video/uikit/SDL_uikitview.m
@@ -375,17 +375,21 @@ CGPoint prevpoint;
     
     if (recognizer.numberOfTouches == 1)
     {
-        SDL_SendMouseButton(0, SDL_PRESSED, SDL_BUTTON_LEFT);
-        // Must have or won't work
-        [NSThread sleepForTimeInterval:0.1];
-        SDL_SendMouseButton(0, SDL_RELEASED, SDL_BUTTON_LEFT);
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+            SDL_SendMouseButton(0, SDL_PRESSED, SDL_BUTTON_LEFT);
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+                SDL_SendMouseButton(0, SDL_RELEASED, SDL_BUTTON_LEFT);
+            });
+        });
     }
     else if (recognizer.numberOfTouches == 2)
     {
-        SDL_SendMouseButton(0, SDL_PRESSED, SDL_BUTTON_RIGHT);
-        // Must have or won't work
-        [NSThread sleepForTimeInterval:0.1];
-        SDL_SendMouseButton(0, SDL_RELEASED, SDL_BUTTON_RIGHT);
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+            SDL_SendMouseButton(0, SDL_PRESSED, SDL_BUTTON_RIGHT);
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+                SDL_SendMouseButton(0, SDL_RELEASED, SDL_BUTTON_RIGHT);
+            });
+        });
     }
     return;
 }


### PR DESCRIPTION
This PR introduces the following changes:
 - Call `makeKeyAndVisible` on the main thread in order to prevent a crash in `iOS 13`. 
 - Dispatch the mouse events asynchronously in order to avoid blocking the main thread.

I tested this by playing a few hours of Heroes 2 on the iPad and the mouse events worked perfectly.